### PR TITLE
Support tabs for indentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1429,6 +1429,11 @@
         "graceful-readlink": "1.0.1"
       }
     },
+    "common-prefix": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/common-prefix/-/common-prefix-1.1.0.tgz",
+      "integrity": "sha1-46Xqf6+u/H64TnYFI+GvuYX5DwA="
+    },
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   ],
   "dependencies": {
     "babylon": "6.18.0",
+    "common-prefix": "^1.1.0",
     "pug-error": "^1.3.2",
     "pug-filters": "^2.1.2",
     "pug-lexer": "^3.1.0",

--- a/src/__tests__/__snapshots__/tabs.test.js.snap
+++ b/src/__tests__/__snapshots__/tabs.test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`JavaScript output: transformed source code 1`] = `
+"'use strict';
+
+if (true) {
+	module.exports = <div><div className=\\"foo\\">Hi there</div></div>;
+}"
+`;
+
+exports[`html output: generated html 1`] = `
+<div>
+  <div
+    className="foo"
+  >
+    Hi there
+  </div>
+</div>
+`;
+
+exports[`static html output: static html 1`] = `"<div><div class=\\"foo\\">Hi there</div></div>"`;

--- a/src/__tests__/tabs.input.js
+++ b/src/__tests__/tabs.input.js
@@ -1,0 +1,9 @@
+'use strict';
+
+if (true) {
+  module.exports = pug`
+		div
+			.foo
+				| Hi there
+	`;
+}

--- a/src/__tests__/tabs.test.js
+++ b/src/__tests__/tabs.test.js
@@ -1,0 +1,3 @@
+import testHelper from './test-helper';
+
+testHelper(__dirname + '/tabs.input.js');

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import common from 'common-prefix';
 import parsePug from './parse-pug';
 import Context from './context';
 import {visitExpression} from './visitors';
@@ -36,13 +37,13 @@ export default function(babel) {
 
           let src = template.split('\n');
 
-          const minIndent = src.reduce((minIndent, line) => {
-            return line.trim().length
-              ? Math.min(/^ */.exec(line)[0].length, minIndent)
-              : minIndent;
-          }, Infinity);
+          const minIndent = common(
+            src
+              .filter(line => line.trim() !== '')
+              .map(line => /^[ \t]*/.exec(line)[0]),
+          );
 
-          src = src.map(line => line.substr(minIndent)).join('\n');
+          src = src.map(line => line.substr(minIndent.length)).join('\n');
 
           const ast = parsePug(src);
           const context = Context.create(this.file, path, interpolationRef);


### PR DESCRIPTION
I tried to add pug template-strings to an existing React project, but found that I was getting an error `unexpected token "indent"` on all of the JSX templates I converted. After investigation, I found that the library compensates for indentation by counting spaces, but this project is using tabs to indent. Thus the indentation is not removed and when the Pug parser gets the template string it finds that the first line is indented and throws an error. This pull request instead changes this logic to look for the longest common prefix of spaces and tabs (ignoring blank lines). This will work with both space- and tab-based indentation, plus any mixed indentation should it be used.

I have also commit 17c3cf9 which is the result of NPM changing the lockfile during `npm install`; I don't really understand why it has done this. Additionally, I tried linting the project but got this error:
```
Error: forbeslindesay:
        Configuration for rule "no-labels" is invalid:
        Value "2,[object Object]" has more items than allowed.
```
Therefore, the code has not been linted so the style may not be correct.