### PR TITLE
Add missed dependency: lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "flow-bin": "^0.65.0",
     "husky": "^0.14.3",
     "jest": "^22.1.4",
+    "lint-staged": "^7.0.0",
     "prettier": "1.11.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",


### PR DESCRIPTION
I'm sorry but it looks like I missed a line in dependency list. It was not necessary on CI, so it passed well.