### PR TITLE
Add supporting of XHTML entities (like &nbsp;)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-transform-react-pug",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3413,6 +3413,11 @@
         "hoek": "4.2.1",
         "sntp": "2.1.0"
       }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
     },
     "hoek": {
       "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "babylon": "6.18.0",
     "common-prefix": "^1.1.0",
+    "he": "^1.1.1",
     "pug-error": "^1.3.2",
     "pug-filters": "^3.0.1",
     "pug-lexer": "^4.0.0",

--- a/src/__tests__/__snapshots__/attributes-shorthand.test.js.snap
+++ b/src/__tests__/__snapshots__/attributes-shorthand.test.js.snap
@@ -1,10 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`JavaScript output: transformed source code 1`] = `
-"const test = 10;
-
-module.exports = <div data-first={true} data-second={true} data-positive={true} data-negative={false} data-check={true}><div data-one={true} data-two={true} /></div>;"
-`;
+exports[`JavaScript output: transformed source code 1`] = `"module.exports = <div data-first={true} data-second={true} data-positive={true} data-negative={false} data-check={true}><div data-one={true} data-two={true} /></div>;"`;
 
 exports[`html output: generated html 1`] = `
 <div

--- a/src/__tests__/__snapshots__/attributes-shorthand.test.js.snap
+++ b/src/__tests__/__snapshots__/attributes-shorthand.test.js.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`JavaScript output: transformed source code 1`] = `
-"// To prevent warnings in console from react
-const test = 10;
+"const test = 10;
 
 module.exports = <div data-first={true} data-second={true} data-positive={true} data-negative={false} data-check={true}><div data-one={true} data-two={true} /></div>;"
 `;

--- a/src/__tests__/__snapshots__/html-entities.test.js.snap
+++ b/src/__tests__/__snapshots__/html-entities.test.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`JSX output: generated JSX 1`] = `
+"module.exports = [React.createElement(
+  \\"p\\",
+  null,
+  \\"w \\\\xA0 w\\"
+), React.createElement(
+  \\"p\\",
+  null,
+  \\"w & w\\"
+), React.createElement(
+  \\"p\\",
+  null,
+  \\"w & w\\"
+), React.createElement(
+  \\"p\\",
+  null,
+  \\"w\\\\xF4w\\"
+), React.createElement(
+  \\"p\\",
+  null,
+  \\"\\\\\\\\u00a0\\"
+), React.createElement(
+  \\"p\\",
+  null,
+  \\"w < w\\"
+)];"
+`;
+
+exports[`JavaScript output: transformed source code 1`] = `"module.exports = [<p>w   w</p>, <p>w & w</p>, <p>w & w</p>, <p>wôw</p>, <p>\\\\u00a0</p>, <p>w < w</p>];"`;

--- a/src/__tests__/attributes-shorthand.input.js
+++ b/src/__tests__/attributes-shorthand.input.js
@@ -1,4 +1,3 @@
-// To prevent warnings in console from react
 const test = 10;
 
 module.exports = pug`

--- a/src/__tests__/attributes-shorthand.input.js
+++ b/src/__tests__/attributes-shorthand.input.js
@@ -1,5 +1,3 @@
-const test = 10;
-
 module.exports = pug`
   div(
     data-first

--- a/src/__tests__/html-entities.input.js
+++ b/src/__tests__/html-entities.input.js
@@ -1,0 +1,8 @@
+module.exports = pug`
+  p w &nbsp; w
+  p w &amp; w
+  p w & w
+  p wôw
+  p \u00a0
+  p w < w
+`;

--- a/src/__tests__/html-entities.test.js
+++ b/src/__tests__/html-entities.test.js
@@ -1,0 +1,22 @@
+import {transformFileSync} from 'babel-core';
+import transformReactPug from '../';
+import transformReactJsx from 'babel-plugin-transform-react-jsx';
+
+const FILENAME = __dirname + '/html-entities.input.js';
+
+const transform = (...plugins) =>
+  transformFileSync(FILENAME, {
+    babelrc: false,
+    compact: false,
+    plugins: [transformReactPug, ...plugins],
+  }).code;
+
+test('JavaScript output', () => {
+  const src = transform();
+  expect(src).toMatchSnapshot('transformed source code');
+});
+
+test('JSX output', () => {
+  const src = transform(transformReactJsx);
+  expect(src).toMatchSnapshot('generated JSX');
+});

--- a/src/utils/sanitize-text.js
+++ b/src/utils/sanitize-text.js
@@ -1,0 +1,7 @@
+// @flow
+
+import he from 'he';
+
+export default function(input: string): string {
+  return he.decode(input);
+}

--- a/src/visitors/Text.js
+++ b/src/visitors/Text.js
@@ -2,6 +2,7 @@
 
 import type Context from '../context';
 import t from '../babel-types';
+import sanitizeText from '../utils/sanitize-text';
 import {
   INTERPOLATION_REFERENCE_REGEX,
   getInterpolationRefs,
@@ -59,7 +60,10 @@ const TextVisitor = {
     if (/^\s/.test(val) || /\s$/.test(val)) {
       return t.jSXExpressionContainer(t.stringLiteral(val));
     }
-    return t.jSXText(val);
+
+    const content = sanitizeText(val);
+
+    return t.jSXText(content);
   },
   expression({val}: {val: string}, context: Context) {
     const refs = getInterpolationRefs(val);


### PR DESCRIPTION
Here is initial issue: #21 

## Explanation of the problem

After investigating of why JSX does not handle xhtml-entities I realized that they do it during 'parse'-phase (they go through all `JSXText` elements and transform content inside). Their main idea is to keep tokens and AST already sanitized, so all plugins will get correct unicode characters.

The path looks so:

```
         parse:     transform:             generate:
INPUT -> babylon -> transform-react-jsx -> babylon   -> OUTPUT
```

And our plugin goes after 'parse'-phase as well:

```
         parse:     transform:                                    generate:
INPUT -> babylon -> transform-react-pug -> transform-react-jsx -> babylon   -> OUTPUT
```

This all means that when we add our plugin it does not have any `JSXText` on 'parse'-phase, it has template literal with pug. So it does not sanitize xhtml-entities (because no `JSXText`).

I discussed it in [babel's official slack](https://slack.babeljs.io/) and it looks like they are aware of it and it happens by design. So we have to handle XHTML-entities on our end.