### PR TITLE
Wraps multiple elements in <React.Fragment>

### DIFF
--- a/src/__tests__/__snapshots__/html-entities.test.js.snap
+++ b/src/__tests__/__snapshots__/html-entities.test.js.snap
@@ -1,31 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`JSX output: generated JSX 1`] = `
-"module.exports = [React.createElement(
-  \\"p\\",
+"module.exports = React.createElement(
+  React.Fragment,
   null,
-  \\"w \\\\xA0 w\\"
-), React.createElement(
-  \\"p\\",
-  null,
-  \\"w & w\\"
-), React.createElement(
-  \\"p\\",
-  null,
-  \\"w & w\\"
-), React.createElement(
-  \\"p\\",
-  null,
-  \\"w\\\\xF4w\\"
-), React.createElement(
-  \\"p\\",
-  null,
-  \\"\\\\\\\\u00a0\\"
-), React.createElement(
-  \\"p\\",
-  null,
-  \\"w < w\\"
-)];"
+  React.createElement(
+    \\"p\\",
+    null,
+    \\"w \\\\xA0 w\\"
+  ),
+  React.createElement(
+    \\"p\\",
+    null,
+    \\"w & w\\"
+  ),
+  React.createElement(
+    \\"p\\",
+    null,
+    \\"w & w\\"
+  ),
+  React.createElement(
+    \\"p\\",
+    null,
+    \\"w\\\\xF4w\\"
+  ),
+  React.createElement(
+    \\"p\\",
+    null,
+    \\"\\\\\\\\u00a0\\"
+  ),
+  React.createElement(
+    \\"p\\",
+    null,
+    \\"w < w\\"
+  )
+);"
 `;
 
-exports[`JavaScript output: transformed source code 1`] = `"module.exports = [<p>w   w</p>, <p>w & w</p>, <p>w & w</p>, <p>wôw</p>, <p>\\\\u00a0</p>, <p>w < w</p>];"`;
+exports[`JavaScript output: transformed source code 1`] = `"module.exports = <React.Fragment><p>w   w</p><p>w & w</p><p>w & w</p><p>wôw</p><p>\\\\u00a0</p><p>w < w</p></React.Fragment>;"`;

--- a/src/__tests__/__snapshots__/react-fragment.test.js.snap
+++ b/src/__tests__/__snapshots__/react-fragment.test.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`JavaScript output: transformed source code 1`] = `"module.exports = <React.Fragment><div /><div /></React.Fragment>;"`;
+
+exports[`html output: generated html 1`] = `
+Array [
+  <div />,
+  <div />,
+]
+`;
+
+exports[`static html output: static html 1`] = `"<div></div><div></div>"`;

--- a/src/__tests__/react-fragment.input.js
+++ b/src/__tests__/react-fragment.input.js
@@ -1,0 +1,4 @@
+module.exports = pug`
+  div
+  div
+`;

--- a/src/__tests__/react-fragment.test.js
+++ b/src/__tests__/react-fragment.test.js
@@ -1,0 +1,3 @@
+import testHelper from './test-helper';
+
+testHelper(__dirname + '/react-fragment.input.js');

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import parsePug from './parse-pug';
 import Context from './context';
 import {visitExpression} from './visitors';
 import {getInterpolatedTemplate} from './utils/interpolation';
-import {buildJSXElement, buildJSXFragment} from './utils/jsx';
+import {buildJSXFragment} from './utils/jsx';
 import {setBabelTypes} from './babel-types';
 
 export default function(babel) {

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import parsePug from './parse-pug';
 import Context from './context';
 import {visitExpression} from './visitors';
 import {getInterpolatedTemplate} from './utils/interpolation';
+import {buildJSXElement, buildJSXFragment} from './utils/jsx';
 import {setBabelTypes} from './babel-types';
 
 export default function(babel) {
@@ -50,10 +51,11 @@ export default function(babel) {
           const transformed = ast.nodes.map(node =>
             visitExpression(node, context),
           );
+
           const expression =
             transformed.length === 1
               ? transformed[0]
-              : t.arrayExpression(transformed);
+              : buildJSXFragment(transformed);
 
           context.variablesToDeclare.forEach(id => {
             path.scope.push({kind: 'let', id});

--- a/src/utils/jsx.js
+++ b/src/utils/jsx.js
@@ -1,0 +1,29 @@
+// @flow
+
+import t from '../babel-types';
+
+type JSXChildren = Array<
+  JSXText | JSXExpressionContainer | JSXSpreadChild | JSXElement,
+>;
+
+export function buildJSXElement(
+  tag: JSXIdentifier | JSXMemberExpression,
+  attrs: Array<JSXAttribute | JSXSpreadAttribute>,
+  children: JSXChildren,
+): JSXElement {
+  const noChildren = children.length === 0;
+
+  const open = t.jSXOpeningElement(tag, attrs, noChildren);
+
+  const close = noChildren ? null : t.jSXClosingElement(tag);
+
+  return t.jSXElement(open, close, children, noChildren);
+}
+
+export function buildJSXFragment(children: JSXChildren): JSXElement {
+  const fragmentExpression = t.jSXMemberExpression(
+    t.jSXIdentifier('React'),
+    t.jSXIdentifier('Fragment'),
+  );
+  return buildJSXElement(fragmentExpression, [], children);
+}

--- a/src/utils/jsx.js
+++ b/src/utils/jsx.js
@@ -20,6 +20,8 @@ export function buildJSXElement(
   return t.jSXElement(open, close, children, noChildren);
 }
 
+// TODO: This can be replaced when migrating to Babel 7 as JSXFragment
+// has been added in v7.0.0-beta.30.
 export function buildJSXFragment(children: JSXChildren): JSXElement {
   const fragmentExpression = t.jSXMemberExpression(
     t.jSXIdentifier('React'),

--- a/src/utils/jsx.js
+++ b/src/utils/jsx.js
@@ -9,7 +9,7 @@ type JSXChildren = Array<
 export function buildJSXElement(
   tag: JSXIdentifier | JSXMemberExpression,
   attrs: Array<JSXAttribute | JSXSpreadAttribute>,
-  children: JSXChildren,
+  children?: JSXChildren,
 ): JSXElement {
   const noChildren = children.length === 0;
 

--- a/src/utils/jsx.js
+++ b/src/utils/jsx.js
@@ -9,7 +9,7 @@ type JSXChildren = Array<
 export function buildJSXElement(
   tag: JSXIdentifier | JSXMemberExpression,
   attrs: Array<JSXAttribute | JSXSpreadAttribute>,
-  children?: JSXChildren,
+  children: JSXChildren,
 ): JSXElement {
   const noChildren = children.length === 0;
 


### PR DESCRIPTION
This fixes #26.

# Overview

If there are multiple root elements specified, these will now be wrapped in a `React.Fragment`.

# Example

## In
```js
const BookInfo = () => pug`
  div
  div
`
```

## Out
```js
const BookInfo = () => <React.Fragment><div/><div/></React.Fragment>
```

# *Note: Babel 7*
 
`buildJSXFragment` can be replaced when migrating to Babel 7 as `JSXFragment` has been added in [v7.0.0-beta.30](https://github.com/babel/babylon/releases/tag/v7.0.0-beta.30).

Therefore `buildJSXFragment` functionality can be achieved by:

```js
t.jSXFragment(t.jSXOpeningFragment(), t.jSXClosingFragment(), children)
```
