### PR TITLE
Enable AST explicitly

### DIFF
--- a/src/utils/parse.js
+++ b/src/utils/parse.js
@@ -6,6 +6,7 @@ import {transform} from 'babel-core';
 export default function parse(src: string, context: Context): Array<Statement> {
   try {
     return transform(src, {
+      ast: true,
       babelrc: false,
       code: false,
       parserOpts: context.file.parserOpts,


### PR DESCRIPTION
When using with `@babel/core`, an error occurred because generating __AST__ was disabled in default since Babel goes to v7.

In _Babel 6_, __AST__ is __enabled__ in default: [babel-core#options](https://babeljs.io/docs/en/babel-core#options)

But is __disabled__ in _Babel 7_: [@babel/core#options](https://babeljs.io/docs/en/next/babel-core#options)

![2018-07-01 11 13 33](https://user-images.githubusercontent.com/11359892/42136088-f95f4126-7d87-11e8-80be-957c491ea17f.png)

Although this plugin seems will not get maintain of compatibility with babel 7 right now (#30), but it still can used with babel 7 by a little bit change. Hope you can release a patch version for me 😢

Minimal `package.json`:
```js
...
"@babel/core": "^7.0.0-beta.51",
// This module exports `@babel/core` as `require('babel-core')` so we can
// use `babel-plugin-transform-react-pug` with Babel 7
"babel-core": "7.0.0-bridge.0",
"babel-plugin-transform-react-pug": "^6.0.0",
...
```
