### PR TITLE
Fill some missed parts in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,18 @@ _Coming soon..._
 
 * We can't use dots in component names because pugjs treats everything after dot as a className. For example, `React.Fragment` becomes `<React className="Fragment" />`, not `<React.Fragment />`
 
+  A nice workaround is made by [babel-plugin-transform-jsx-classname-components](https://github.com/ezhlobo/babel-plugin-transform-jsx-classname-components). Just add it to `.babelrc`:
+  
+  ```rc
+  {
+    "plugins": [
+      ["transform-jsx-classname-components", {
+        "objects": ["React"]
+      }]
+    ]
+  }
+  ```
+
 ## FAQ
 
 ### Can I import template from other files?

--- a/README.md
+++ b/README.md
@@ -219,9 +219,7 @@ _Coming soon..._
 
 ### Can I import template from other files?
 
-No.
-
-_Coming soon..._
+The short answer is no and we are not going to implement that in near future. Take a look at [initial request with small explanation (#15)](https://github.com/pugjs/babel-plugin-transform-react-pug/issues/15).
 
 ### How to get syntax highlighting in IDE (or text editors)?
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# babel-plugin-transform-react-pug [![npm version](https://img.shields.io/npm/v/babel-plugin-transform-react-pug.svg)](https://www.npmjs.com/package/babel-plugin-transform-react-pug)
+# babel-plugin-transform-react-pug
 
 Use Pug templates to write react components.
+
+[![npm version](https://img.shields.io/npm/v/babel-plugin-transform-react-pug.svg)](https://www.npmjs.com/package/babel-plugin-transform-react-pug) [![Build Status](https://travis-ci.org/pugjs/babel-plugin-transform-react-pug.svg?branch=master)](https://travis-ci.org/pugjs/babel-plugin-transform-react-pug)
 
 `babel-plugin-transform-react-pug` is a plugin for babel which transpiles pug syntax within template literals to jsx.
 


### PR DESCRIPTION
* Make badges more readable
* Add workaround for handling dot notation
* Add a link to the issue, why we don't have the possibility to require templates