### PR TITLE
Fix babel using unexpected configs in Babel@7

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ It's not supported well yet.
     npm install --save-dev babel-plugin-transform-react-pug
     ```
 
-2.  Add to babel configuration before transpiling jsx (usually in `.babelrc`)
+2.  Add to babel configuration before transpiling jsx (usually in `.babelrc`, or `babel.config.js` with Babel@7)
 
     ```
     {
@@ -205,7 +205,7 @@ _Coming soon..._
 * We can't use dots in component names because pugjs treats everything after dot as a className. For example, `React.Fragment` becomes `<React className="Fragment" />`, not `<React.Fragment />`
 
   A nice workaround is made by [babel-plugin-transform-jsx-classname-components](https://github.com/ezhlobo/babel-plugin-transform-jsx-classname-components). Just add it to `.babelrc`:
-  
+
   ```rc
   {
     "plugins": [
@@ -241,7 +241,7 @@ The short answer is no and we are not going to implement that in near future. Ta
    * Prefix: `<template lang="pug">`
    * Suffix: `</template>`
    * Places Patterns: `+ taggedString("pug")`
-    
+
 4. Click "OK" and "Apply"
 
 #### Atom

--- a/src/utils/parse.js
+++ b/src/utils/parse.js
@@ -8,6 +8,7 @@ export default function parse(src: string, context: Context): Array<Statement> {
     return transform(src, {
       ast: true,
       babelrc: false,
+      configFile: false,
       code: false,
       parserOpts: context.file.parserOpts,
       plugins: [


### PR DESCRIPTION
Error occurred when using Babel@7 with new `babel.config.js` file.

It works correctly when using `.babelrc` or `.babelrc.js` as babel config filename, `babel-plugin-transform-react-pug` will not deal with these file, but `babel.config.js`.

![2018-09-10 3 27 57](https://user-images.githubusercontent.com/11359892/45282853-bc697e80-b50e-11e8-8af3-a46c64f26c0d.png)

The solution is add `configFile: false` into parse options:

https://babeljs.io/docs/en/next/options#configfile