### PR TITLE
Make sure that if we provide only code (if, each, inline code), it operates

### DIFF
--- a/src/__tests__/__snapshots__/if-else.test.js.snap
+++ b/src/__tests__/__snapshots__/if-else.test.js.snap
@@ -17,9 +17,9 @@ exports[`JavaScript output: transformed source code 1`] = `
             {v === 1 ? \\"One\\" : v === 2 ? \\"Two\\" : \\"Many\\"}
             {v === 3
               ? [<strong key=\\"pug:2:0\\">Three</strong>, \\"is the magic number!\\"]
-              : undefined}
+              : null}
             {v == 2
-              ? undefined
+              ? null
               : [<strong key=\\"pug:5:0\\">Definitely</strong>, \\"not 2\\"]}
           </div>
         );

--- a/src/__tests__/__snapshots__/interpolation.test.js.snap
+++ b/src/__tests__/__snapshots__/interpolation.test.js.snap
@@ -22,11 +22,7 @@ module.exports = new function() {
         {\\"\\\\n\\"}
         {[\\"one being \\", this.names[1], \\"!\\"].join(\\"\\")}
       </p>
-      {showFirstPerson ? (
-        <Person name={this.names[0]} key=\\"pug:0:0\\" />
-      ) : (
-        undefined
-      )}
+      {showFirstPerson ? <Person name={this.names[0]} key=\\"pug:0:0\\" /> : null}
       {this.names.map((name, key) => (
         <p key={key}>{[\\"Hi \\", name, \\", bye \\", name].join(\\"\\")}</p>
       ))}

--- a/src/__tests__/__snapshots__/nested-loops.test.js.snap
+++ b/src/__tests__/__snapshots__/nested-loops.test.js.snap
@@ -14,7 +14,7 @@ exports[`JavaScript output: transformed source code 1`] = `
         let _name;
 
         const a = _pug_arr[_pug_index];
-        _pug_nodes[_pug_nodes.length] = ((_name = \\"a\\"), undefined);
+        _pug_nodes[_pug_nodes.length] = ((_name = \\"a\\"), null);
         _pug_nodes[_pug_nodes.length] = (
           <div key={\\"pug\\" + a + \\":0\\"}>
             {_name + \\":\\" + a}
@@ -33,7 +33,7 @@ exports[`JavaScript output: transformed source code 1`] = `
                 let _name2;
 
                 const b = _pug_arr2[_pug_index2];
-                _pug_nodes2[_pug_nodes2.length] = ((_name2 = \\"b\\"), undefined);
+                _pug_nodes2[_pug_nodes2.length] = ((_name2 = \\"b\\"), null);
                 _pug_nodes2[_pug_nodes2.length] = (
                   <div key={\\"pug\\" + b + \\":0\\"}>{_name2 + \\":\\" + b}</div>
                 );
@@ -52,7 +52,7 @@ exports[`JavaScript output: transformed source code 1`] = `
                 let _name3;
 
                 const c = _pug_arr3[i];
-                _pug_nodes3[_pug_nodes3.length] = ((_name3 = \\"c\\"), undefined);
+                _pug_nodes3[_pug_nodes3.length] = ((_name3 = \\"c\\"), null);
                 _pug_nodes3[_pug_nodes3.length] = (
                   <div key={\\"pug\\" + c + \\":0\\"}>{_name3 + c}</div>
                 );

--- a/src/__tests__/__snapshots__/plain-js.test.js.snap
+++ b/src/__tests__/__snapshots__/plain-js.test.js.snap
@@ -1,0 +1,102 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`code JavaScript output: transformed source code 1`] = `
+"const log = text => text;
+
+module.exports = (log(\\"Hello\\"), null);
+"
+`;
+
+exports[`code html output: generated html 1`] = `null`;
+
+exports[`code static html output: static html 1`] = `""`;
+
+exports[`code-multiline JavaScript output: transformed source code 1`] = `
+"let _greeting;
+
+const log = text => text;
+
+module.exports = (
+  <React.Fragment>
+    {((_greeting = \\"hello\\"), null)}
+    {(log(_greeting), null)}
+  </React.Fragment>
+);
+"
+`;
+
+exports[`code-multiline html output: generated html 1`] = `null`;
+
+exports[`code-multiline static html output: static html 1`] = `""`;
+
+exports[`each JavaScript output: transformed source code 1`] = `
+"module.exports = ((_pug_nodes, _pug_arr) => {
+  if (!(_pug_arr == null || Array.isArray(_pug_arr)))
+    throw new Error(
+      'Expected \\"[1, 2, 3]\\" to be an array because it is passed to each.'
+    );
+  if (_pug_arr == null || _pug_arr.length === 0) return undefined;
+
+  for (let _pug_index = 0; _pug_index < _pug_arr.length; _pug_index++) {
+    const item = _pug_arr[_pug_index];
+    _pug_nodes[_pug_nodes.length] = <div key={\\"pug\\" + item + \\":0\\"}>{item}</div>;
+  }
+
+  return _pug_nodes;
+})([], [1, 2, 3]);
+"
+`;
+
+exports[`each html output: generated html 1`] = `
+Array [
+  <div>
+    1
+  </div>,
+  <div>
+    2
+  </div>,
+  <div>
+    3
+  </div>,
+]
+`;
+
+exports[`each static html output: static html 1`] = `"<div>1</div><div>2</div><div>3</div>"`;
+
+exports[`if JavaScript output: transformed source code 1`] = `
+"module.exports = false ? <p key=\\"pug:0:0\\">Truthy</p> : null;
+"
+`;
+
+exports[`if html output: generated html 1`] = `null`;
+
+exports[`if static html output: static html 1`] = `""`;
+
+exports[`while JavaScript output: transformed source code 1`] = `
+"let n = 0;
+
+module.exports = (_pug_nodes => {
+  while (n < 3) {
+    _pug_nodes[_pug_nodes.length] = <div key={n}>{n++}</div>;
+  }
+
+  return _pug_nodes;
+})([]);
+"
+`;
+
+exports[`while html output: generated html 1`] = `
+Array [
+  <div>
+    0
+  </div>,
+  <div>
+    1
+  </div>,
+  <div>
+    2
+  </div>,
+]
+`;
+
+exports[`while static html output: static html 1`] = `"<div>0</div><div>1</div><div>2</div>"`;

--- a/src/__tests__/__snapshots__/plain-js.test.js.snap
+++ b/src/__tests__/__snapshots__/plain-js.test.js.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`case JavaScript output: transformed source code 1`] = `
+"const n = 0;
+
+module.exports =
+  n === 1 ? (
+    <p key=\\"pug:0:0\\">One</p>
+  ) : n === 2 ? (
+    <p key=\\"pug:1:0\\">Two</p>
+  ) : null;
+"
+`;
+
+exports[`case html output: generated html 1`] = `null`;
+
+exports[`case static html output: static html 1`] = `""`;
+
 exports[`code JavaScript output: transformed source code 1`] = `
 "const log = text => text;
 

--- a/src/__tests__/__snapshots__/react-fragment.test.js.snap
+++ b/src/__tests__/__snapshots__/react-fragment.test.js.snap
@@ -66,7 +66,7 @@ exports[`with each static html output: static html 1`] = `"<div>1</div><div>2</d
 exports[`with if JavaScript output: transformed source code 1`] = `
 "module.exports = (
   <React.Fragment>
-    {true ? <div key=\\"pug:0:0\\">Truthy</div> : undefined}
+    {true ? <div key=\\"pug:0:0\\">Truthy</div> : null}
     <div>Next item</div>
   </React.Fragment>
 );
@@ -91,7 +91,7 @@ exports[`with inline javascript JavaScript output: transformed source code 1`] =
 
 module.exports = (
   <React.Fragment>
-    {((_i = 100), undefined)}
+    {((_i = 100), null)}
     <div>{_i}</div>
   </React.Fragment>
 );

--- a/src/__tests__/__snapshots__/text.test.js.snap
+++ b/src/__tests__/__snapshots__/text.test.js.snap
@@ -6,7 +6,7 @@ exports[`JavaScript output: transformed source code 1`] = `
     Hello World
     {\\"\\\\n\\"}
     What a great world it is
-    {10 < 15 ? \\" The world is great\\" : undefined}
+    {10 < 15 ? \\" The world is great\\" : null}
     <div>
       Longer passages of text work
       {\\"\\\\n\\"}

--- a/src/__tests__/__snapshots__/variable-declaration.test.js.snap
+++ b/src/__tests__/__snapshots__/variable-declaration.test.js.snap
@@ -5,9 +5,9 @@ exports[`JavaScript output: transformed source code 1`] = `
 
 module.exports = (
   <div>
-    {((_x = 1), undefined)}
-    {((_x = _x + 40), undefined)}
-    {(_x++, undefined)}
+    {((_x = 1), null)}
+    {((_x = _x + 40), null)}
+    {(_x++, null)}
     <div>{_x}</div>
   </div>
 );

--- a/src/__tests__/plain-js-case.input.js
+++ b/src/__tests__/plain-js-case.input.js
@@ -1,0 +1,10 @@
+const n = 0;
+
+module.exports = pug`
+  case n
+    when 1
+      p One
+
+    when 2
+      p Two
+`;

--- a/src/__tests__/plain-js-code-multiline.input.js
+++ b/src/__tests__/plain-js-code-multiline.input.js
@@ -1,0 +1,6 @@
+const log = text => text;
+
+module.exports = pug`
+  - const greeting = 'hello'
+  - log(greeting)
+`;

--- a/src/__tests__/plain-js-code.input.js
+++ b/src/__tests__/plain-js-code.input.js
@@ -1,0 +1,5 @@
+const log = text => text;
+
+module.exports = pug`
+  - log('Hello')
+`;

--- a/src/__tests__/plain-js-each.input.js
+++ b/src/__tests__/plain-js-each.input.js
@@ -1,0 +1,4 @@
+module.exports = pug`
+  each item in [1, 2, 3]
+    div(key=item)= item
+`;

--- a/src/__tests__/plain-js-if.input.js
+++ b/src/__tests__/plain-js-if.input.js
@@ -1,0 +1,4 @@
+module.exports = pug`
+  if false
+    p Truthy
+`;

--- a/src/__tests__/plain-js-while.input.js
+++ b/src/__tests__/plain-js-while.input.js
@@ -1,0 +1,6 @@
+let n = 0;
+
+module.exports = pug`
+  while n < 3
+    div(key=n)= n++
+`;

--- a/src/__tests__/plain-js.test.js
+++ b/src/__tests__/plain-js.test.js
@@ -19,3 +19,7 @@ describe('each', () => {
 describe('while', () => {
   testHelper(__dirname + '/plain-js-while.input.js');
 });
+
+describe('case', () => {
+  testHelper(__dirname + '/plain-js-case.input.js');
+});

--- a/src/__tests__/plain-js.test.js
+++ b/src/__tests__/plain-js.test.js
@@ -1,0 +1,21 @@
+import testHelper from './test-helper';
+
+describe('code', () => {
+  testHelper(__dirname + '/plain-js-code.input.js');
+});
+
+describe('code-multiline', () => {
+  testHelper(__dirname + '/plain-js-code-multiline.input.js');
+});
+
+describe('if', () => {
+  testHelper(__dirname + '/plain-js-if.input.js');
+});
+
+describe('each', () => {
+  testHelper(__dirname + '/plain-js-each.input.js');
+});
+
+describe('while', () => {
+  testHelper(__dirname + '/plain-js-while.input.js');
+});

--- a/src/visitors/Case.js
+++ b/src/visitors/Case.js
@@ -11,7 +11,7 @@ function convertCases(
   needle: Identifier,
 ): Expression {
   if (nodes.length === 0) {
-    return t.identifier('undefined');
+    return t.identifier('null');
   }
   const node = nodes[0];
   const consequent = context.staticBlock(
@@ -21,7 +21,7 @@ function convertCases(
         return children[0];
       }
       if (children.length === 0) {
-        return t.identifier('undefined');
+        return t.identifier('null');
       }
       return t.arrayExpression(children);
     },

--- a/src/visitors/Code.js
+++ b/src/visitors/Code.js
@@ -64,14 +64,11 @@ function visitUnbufferedCode(node: Object, context: Context) {
         ),
       );
     }
-    expressions.push(t.identifier('undefined'));
+    expressions.push(t.identifier('null'));
     return t.sequenceExpression(expressions);
   }
   if (t.isExpressionStatement(statement)) {
-    return t.sequenceExpression([
-      statement.expression,
-      t.identifier('undefined'),
-    ]);
+    return t.sequenceExpression([statement.expression, t.identifier('null')]);
   }
   return t.callExpression(
     t.arrowFunctionExpression([], t.blockStatement([statement])),

--- a/src/visitors/Conditional.js
+++ b/src/visitors/Conditional.js
@@ -21,7 +21,7 @@ const ConditionalVisitor = {
           return children[0];
         }
         if (children.length === 0) {
-          return t.identifier('undefined');
+          return t.identifier('null');
         }
         return t.arrayExpression(children);
       },
@@ -40,7 +40,7 @@ const ConditionalVisitor = {
           return children[0];
         }
         if (children.length === 0) {
-          return t.identifier('undefined');
+          return t.identifier('null');
         }
         return t.arrayExpression(children);
       },


### PR DESCRIPTION
It basically makes sure that following snippet won't render anything. Before that it crashed with the error.

```jsx
pug`
  if false
    p Hello
`
```

How it works: now instead of transforming falsy-branch into `undefined`, we transform it into `null`. JSX+React works perfectly with `null`.