### PR TITLE
Convert loops into .map way

### DIFF
--- a/src/__tests__/__snapshots__/each-else.test.js.snap
+++ b/src/__tests__/__snapshots__/each-else.test.js.snap
@@ -5,15 +5,15 @@ exports[`JavaScript output: transformed source code 1`] = `
   <div>
     {[[1, 2, 3], [], null].map((list, i) => {
       return (
-        <div key={\\"pug\\" + i + \\":0\\"}>
+        <div key={i}>
           {Array.isArray(list) && list.length
             ? list.map(item => {
-                return <span key={\\"pug\\" + item + \\":0\\"}>{item}</span>;
+                return <span key={item}>{item}</span>;
               })
             : \\"No items in this list\\"}
           {Array.isArray(list) && list.length
             ? list.map(item => {
-                return <span key={\\"pug\\" + item + \\":0\\"}>{item}</span>;
+                return <span key={item}>{item}</span>;
               })
             : [
                 \\"This is \\",

--- a/src/__tests__/__snapshots__/each-else.test.js.snap
+++ b/src/__tests__/__snapshots__/each-else.test.js.snap
@@ -3,69 +3,26 @@
 exports[`JavaScript output: transformed source code 1`] = `
 "module.exports = (
   <div>
-    {((_pug_nodes, _pug_arr) => {
-      if (!(_pug_arr == null || Array.isArray(_pug_arr)))
-        throw new Error(
-          'Expected \\"[[1, 2, 3], [], null]\\" to be an array because it is passed to each.'
-        );
-      if (_pug_arr == null || _pug_arr.length === 0) return undefined;
-
-      for (let i = 0; i < _pug_arr.length; i++) {
-        const list = _pug_arr[i];
-        _pug_nodes[_pug_nodes.length] = (
-          <div key={\\"pug\\" + i + \\":0\\"}>
-            {((_pug_nodes2, _pug_arr2) => {
-              if (!(_pug_arr2 == null || Array.isArray(_pug_arr2)))
-                throw new Error(
-                  'Expected \\"list\\" to be an array because it is passed to each.'
-                );
-              if (_pug_arr2 == null || _pug_arr2.length === 0)
-                return \\"No items in this list\\";
-
-              for (
-                let _pug_index = 0;
-                _pug_index < _pug_arr2.length;
-                _pug_index++
-              ) {
-                const item = _pug_arr2[_pug_index];
-                _pug_nodes2[_pug_nodes2.length] = (
-                  <span key={\\"pug\\" + item + \\":0\\"}>{item}</span>
-                );
-              }
-
-              return _pug_nodes2;
-            })([], list)}
-            {((_pug_nodes3, _pug_arr3) => {
-              if (!(_pug_arr3 == null || Array.isArray(_pug_arr3)))
-                throw new Error(
-                  'Expected \\"list\\" to be an array because it is passed to each.'
-                );
-              if (_pug_arr3 == null || _pug_arr3.length === 0)
-                return [
-                  \\"This is \\",
-                  <strong key=\\"pug:1:0\\">literally</strong>,
-                  \\" the same list!\\"
-                ];
-
-              for (
-                let _pug_index2 = 0;
-                _pug_index2 < _pug_arr3.length;
-                _pug_index2++
-              ) {
-                const item = _pug_arr3[_pug_index2];
-                _pug_nodes3[_pug_nodes3.length] = (
-                  <span key={\\"pug\\" + item + \\":0\\"}>{item}</span>
-                );
-              }
-
-              return _pug_nodes3;
-            })([], list)}
-          </div>
-        );
-      }
-
-      return _pug_nodes;
-    })([], [[1, 2, 3], [], null])}
+    {[[1, 2, 3], [], null].map((list, i) => {
+      return (
+        <div key={\\"pug\\" + i + \\":0\\"}>
+          {Array.isArray(list) && list.length
+            ? list.map(item => {
+                return <span key={\\"pug\\" + item + \\":0\\"}>{item}</span>;
+              })
+            : \\"No items in this list\\"}
+          {Array.isArray(list) && list.length
+            ? list.map(item => {
+                return <span key={\\"pug\\" + item + \\":0\\"}>{item}</span>;
+              })
+            : [
+                \\"This is \\",
+                <strong key=\\"pug:1:0\\">literally</strong>,
+                \\" the same list!\\"
+              ]}
+        </div>
+      );
+    })}
   </div>
 );
 "

--- a/src/__tests__/__snapshots__/if-else.test.js.snap
+++ b/src/__tests__/__snapshots__/if-else.test.js.snap
@@ -3,30 +3,17 @@
 exports[`JavaScript output: transformed source code 1`] = `
 "module.exports = (
   <div>
-    {((_pug_nodes, _pug_arr) => {
-      if (!(_pug_arr == null || Array.isArray(_pug_arr)))
-        throw new Error(
-          'Expected \\"[1, 2, 3]\\" to be an array because it is passed to each.'
-        );
-      if (_pug_arr == null || _pug_arr.length === 0) return undefined;
-
-      for (let i = 0; i < _pug_arr.length; i++) {
-        const v = _pug_arr[i];
-        _pug_nodes[_pug_nodes.length] = (
-          <div key={\\"pug\\" + i + \\":0\\"}>
-            {v === 1 ? \\"One\\" : v === 2 ? \\"Two\\" : \\"Many\\"}
-            {v === 3
-              ? [<strong key=\\"pug:2:0\\">Three</strong>, \\"is the magic number!\\"]
-              : null}
-            {v == 2
-              ? null
-              : [<strong key=\\"pug:5:0\\">Definitely</strong>, \\"not 2\\"]}
-          </div>
-        );
-      }
-
-      return _pug_nodes;
-    })([], [1, 2, 3])}
+    {[1, 2, 3].map((v, i) => {
+      return (
+        <div key={\\"pug\\" + i + \\":0\\"}>
+          {v === 1 ? \\"One\\" : v === 2 ? \\"Two\\" : \\"Many\\"}
+          {v === 3
+            ? [<strong key=\\"pug:2:0\\">Three</strong>, \\"is the magic number!\\"]
+            : null}
+          {v == 2 ? null : [<strong key=\\"pug:5:0\\">Definitely</strong>, \\"not 2\\"]}
+        </div>
+      );
+    })}
   </div>
 );
 "

--- a/src/__tests__/__snapshots__/if-else.test.js.snap
+++ b/src/__tests__/__snapshots__/if-else.test.js.snap
@@ -5,7 +5,7 @@ exports[`JavaScript output: transformed source code 1`] = `
   <div>
     {[1, 2, 3].map((v, i) => {
       return (
-        <div key={\\"pug\\" + i + \\":0\\"}>
+        <div key={i}>
           {v === 1 ? \\"One\\" : v === 2 ? \\"Two\\" : \\"Many\\"}
           {v === 3
             ? [<strong key=\\"pug:2:0\\">Three</strong>, \\"is the magic number!\\"]

--- a/src/__tests__/__snapshots__/nested-loops.test.js.snap
+++ b/src/__tests__/__snapshots__/nested-loops.test.js.snap
@@ -3,69 +3,32 @@
 exports[`JavaScript output: transformed source code 1`] = `
 "module.exports = (
   <div>
-    {((_pug_nodes, _pug_arr) => {
-      if (!(_pug_arr == null || Array.isArray(_pug_arr)))
-        throw new Error(
-          'Expected \\"[1,2,3]\\" to be an array because it is passed to each.'
-        );
-      if (_pug_arr == null || _pug_arr.length === 0) return undefined;
+    {[1, 2, 3].map(a => {
+      let _name;
 
-      for (let _pug_index = 0; _pug_index < _pug_arr.length; _pug_index++) {
-        let _name;
+      return [
+        ((_name = \\"a\\"), null),
+        <div key={\\"pug\\" + a + \\":0\\"}>
+          {_name + \\":\\" + a}
+          {[1, 2, 3].map(b => {
+            let _name2;
 
-        const a = _pug_arr[_pug_index];
-        _pug_nodes[_pug_nodes.length] = ((_name = \\"a\\"), null);
-        _pug_nodes[_pug_nodes.length] = (
-          <div key={\\"pug\\" + a + \\":0\\"}>
-            {_name + \\":\\" + a}
-            {((_pug_nodes2, _pug_arr2) => {
-              if (!(_pug_arr2 == null || Array.isArray(_pug_arr2)))
-                throw new Error(
-                  'Expected \\"[1,2,3]\\" to be an array because it is passed to each.'
-                );
-              if (_pug_arr2 == null || _pug_arr2.length === 0) return undefined;
+            return [
+              ((_name2 = \\"b\\"), null),
+              <div key={\\"pug\\" + b + \\":0\\"}>{_name2 + \\":\\" + b}</div>
+            ];
+          })}
+          {[1, 2, 3].map((c, i) => {
+            let _name3;
 
-              for (
-                let _pug_index2 = 0;
-                _pug_index2 < _pug_arr2.length;
-                _pug_index2++
-              ) {
-                let _name2;
-
-                const b = _pug_arr2[_pug_index2];
-                _pug_nodes2[_pug_nodes2.length] = ((_name2 = \\"b\\"), null);
-                _pug_nodes2[_pug_nodes2.length] = (
-                  <div key={\\"pug\\" + b + \\":0\\"}>{_name2 + \\":\\" + b}</div>
-                );
-              }
-
-              return _pug_nodes2;
-            })([], [1, 2, 3])}
-            {((_pug_nodes3, _pug_arr3) => {
-              if (!(_pug_arr3 == null || Array.isArray(_pug_arr3)))
-                throw new Error(
-                  'Expected \\"[1,2,3]\\" to be an array because it is passed to each.'
-                );
-              if (_pug_arr3 == null || _pug_arr3.length === 0) return undefined;
-
-              for (let i = 0; i < _pug_arr3.length; i++) {
-                let _name3;
-
-                const c = _pug_arr3[i];
-                _pug_nodes3[_pug_nodes3.length] = ((_name3 = \\"c\\"), null);
-                _pug_nodes3[_pug_nodes3.length] = (
-                  <div key={\\"pug\\" + c + \\":0\\"}>{_name3 + c}</div>
-                );
-              }
-
-              return _pug_nodes3;
-            })([], [1, 2, 3])}
-          </div>
-        );
-      }
-
-      return _pug_nodes;
-    })([], [1, 2, 3])}
+            return [
+              ((_name3 = \\"c\\"), null),
+              <div key={\\"pug\\" + c + \\":0\\"}>{_name3 + c}</div>
+            ];
+          })}
+        </div>
+      ];
+    })}
   </div>
 );
 "

--- a/src/__tests__/__snapshots__/nested-loops.test.js.snap
+++ b/src/__tests__/__snapshots__/nested-loops.test.js.snap
@@ -26,6 +26,31 @@ exports[`JavaScript output: transformed source code 1`] = `
         </div>
       ];
     })}
+    {[[1, 2, 3], [\\"a\\", \\"b\\", \\"c\\"]].map((list, index) => {
+      return list.map(item => {
+        return <div key={item + index} data-value={item} />;
+      });
+    })}
+    {[[1, 2, 3], \\"text\\"].map(list => {
+      return Array.isArray(list)
+        ? list.map(item => {
+            return <p key={item}>{item}</p>;
+          })
+        : null;
+    })}
+    {[1, 2].map(i => {
+      let _anotherArray;
+
+      return [
+        ((_anotherArray = [\\"a\\", \\"b\\", \\"c\\"]), null),
+        _anotherArray.map((item, index) => {
+          return <p key={index}>{item}</p>;
+        })
+      ];
+    })}
+    {[1, 2].map(i => {
+      return [<div key={i}>{i}</div>, <div key={i + 10}>{i}</div>];
+    })}
   </div>
 );
 "
@@ -96,7 +121,64 @@ exports[`html output: generated html 1`] = `
       c3
     </div>
   </div>
+  <div
+    data-value={1}
+  />
+  <div
+    data-value={2}
+  />
+  <div
+    data-value={3}
+  />
+  <div
+    data-value="a"
+  />
+  <div
+    data-value="b"
+  />
+  <div
+    data-value="c"
+  />
+  <p>
+    1
+  </p>
+  <p>
+    2
+  </p>
+  <p>
+    3
+  </p>
+  <p>
+    a
+  </p>
+  <p>
+    b
+  </p>
+  <p>
+    c
+  </p>
+  <p>
+    a
+  </p>
+  <p>
+    b
+  </p>
+  <p>
+    c
+  </p>
+  <div>
+    1
+  </div>
+  <div>
+    1
+  </div>
+  <div>
+    2
+  </div>
+  <div>
+    2
+  </div>
 </div>
 `;
 
-exports[`static html output: static html 1`] = `"<div><div>a:1<div>b:1</div><div>b:2</div><div>b:3</div><div>c1</div><div>c2</div><div>c3</div></div><div>a:2<div>b:1</div><div>b:2</div><div>b:3</div><div>c1</div><div>c2</div><div>c3</div></div><div>a:3<div>b:1</div><div>b:2</div><div>b:3</div><div>c1</div><div>c2</div><div>c3</div></div></div>"`;
+exports[`static html output: static html 1`] = `"<div><div>a:1<div>b:1</div><div>b:2</div><div>b:3</div><div>c1</div><div>c2</div><div>c3</div></div><div>a:2<div>b:1</div><div>b:2</div><div>b:3</div><div>c1</div><div>c2</div><div>c3</div></div><div>a:3<div>b:1</div><div>b:2</div><div>b:3</div><div>c1</div><div>c2</div><div>c3</div></div><div data-value=\\"1\\"></div><div data-value=\\"2\\"></div><div data-value=\\"3\\"></div><div data-value=\\"a\\"></div><div data-value=\\"b\\"></div><div data-value=\\"c\\"></div><p>1</p><p>2</p><p>3</p><p>a</p><p>b</p><p>c</p><p>a</p><p>b</p><p>c</p><div>1</div><div>1</div><div>2</div><div>2</div></div>"`;

--- a/src/__tests__/__snapshots__/nested-loops.test.js.snap
+++ b/src/__tests__/__snapshots__/nested-loops.test.js.snap
@@ -8,23 +8,20 @@ exports[`JavaScript output: transformed source code 1`] = `
 
       return [
         ((_name = \\"a\\"), null),
-        <div key={\\"pug\\" + a + \\":0\\"}>
+        <div key={a}>
           {_name + \\":\\" + a}
           {[1, 2, 3].map(b => {
             let _name2;
 
             return [
               ((_name2 = \\"b\\"), null),
-              <div key={\\"pug\\" + b + \\":0\\"}>{_name2 + \\":\\" + b}</div>
+              <div key={b}>{_name2 + \\":\\" + b}</div>
             ];
           })}
           {[1, 2, 3].map((c, i) => {
             let _name3;
 
-            return [
-              ((_name3 = \\"c\\"), null),
-              <div key={\\"pug\\" + c + \\":0\\"}>{_name3 + c}</div>
-            ];
+            return [((_name3 = \\"c\\"), null), <div key={c}>{_name3 + c}</div>];
           })}
         </div>
       ];

--- a/src/__tests__/__snapshots__/option-class-attribute.test.js.snap
+++ b/src/__tests__/__snapshots__/option-class-attribute.test.js.snap
@@ -16,8 +16,8 @@ module.exports = (
     {[1, 2, 3].map(item => {
       return (
         <p
+          key={item}
           className={\\"seventh-a seventh-b \\" + (\\"seventh-i-\\" + item)}
-          key={\\"pug\\" + item + \\":0\\"}
         />
       );
     })}
@@ -42,9 +42,9 @@ module.exports = (
     {[1, 2, 3].map(item => {
       return (
         <p
+          key={item}
           className={\\"seventh-i-\\" + item}
           styleName=\\"seventh-a seventh-b\\"
-          key={\\"pug\\" + item + \\":0\\"}
         />
       );
     })}

--- a/src/__tests__/__snapshots__/option-class-attribute.test.js.snap
+++ b/src/__tests__/__snapshots__/option-class-attribute.test.js.snap
@@ -13,25 +13,14 @@ module.exports = (
     <p styleName=\\"fourth-a fourth-b\\" />
     <p className=\\"fivth-a fivth-b\\" />
     <p styleName=\\"two\\" className=\\"one\\" />
-    {((_pug_nodes, _pug_arr) => {
-      if (!(_pug_arr == null || Array.isArray(_pug_arr)))
-        throw new Error(
-          'Expected \\"[1, 2, 3]\\" to be an array because it is passed to each.'
-        );
-      if (_pug_arr == null || _pug_arr.length === 0) return undefined;
-
-      for (let _pug_index = 0; _pug_index < _pug_arr.length; _pug_index++) {
-        const item = _pug_arr[_pug_index];
-        _pug_nodes[_pug_nodes.length] = (
-          <p
-            className={\\"seventh-a seventh-b \\" + (\\"seventh-i-\\" + item)}
-            key={\\"pug\\" + item + \\":0\\"}
-          />
-        );
-      }
-
-      return _pug_nodes;
-    })([], [1, 2, 3])}
+    {[1, 2, 3].map(item => {
+      return (
+        <p
+          className={\\"seventh-a seventh-b \\" + (\\"seventh-i-\\" + item)}
+          key={\\"pug\\" + item + \\":0\\"}
+        />
+      );
+    })}
   </div>
 );
 "
@@ -50,26 +39,15 @@ module.exports = (
     <p styleName=\\"fourth-a fourth-b\\" />
     <p className=\\"fivth-a fivth-b\\" />
     <p styleName=\\"one two\\" />
-    {((_pug_nodes, _pug_arr) => {
-      if (!(_pug_arr == null || Array.isArray(_pug_arr)))
-        throw new Error(
-          'Expected \\"[1, 2, 3]\\" to be an array because it is passed to each.'
-        );
-      if (_pug_arr == null || _pug_arr.length === 0) return undefined;
-
-      for (let _pug_index = 0; _pug_index < _pug_arr.length; _pug_index++) {
-        const item = _pug_arr[_pug_index];
-        _pug_nodes[_pug_nodes.length] = (
-          <p
-            className={\\"seventh-i-\\" + item}
-            styleName=\\"seventh-a seventh-b\\"
-            key={\\"pug\\" + item + \\":0\\"}
-          />
-        );
-      }
-
-      return _pug_nodes;
-    })([], [1, 2, 3])}
+    {[1, 2, 3].map(item => {
+      return (
+        <p
+          className={\\"seventh-i-\\" + item}
+          styleName=\\"seventh-a seventh-b\\"
+          key={\\"pug\\" + item + \\":0\\"}
+        />
+      );
+    })}
   </div>
 );
 "

--- a/src/__tests__/__snapshots__/plain-js.test.js.snap
+++ b/src/__tests__/__snapshots__/plain-js.test.js.snap
@@ -47,7 +47,7 @@ exports[`code-multiline static html output: static html 1`] = `""`;
 
 exports[`each JavaScript output: transformed source code 1`] = `
 "module.exports = [1, 2, 3].map(item => {
-  return <div key={\\"pug\\" + item + \\":0\\"}>{item}</div>;
+  return <div key={item}>{item}</div>;
 });
 "
 `;

--- a/src/__tests__/__snapshots__/plain-js.test.js.snap
+++ b/src/__tests__/__snapshots__/plain-js.test.js.snap
@@ -68,6 +68,45 @@ Array [
 
 exports[`each static html output: static html 1`] = `"<div>1</div><div>2</div><div>3</div>"`;
 
+exports[`each-multiple JavaScript output: transformed source code 1`] = `
+"module.exports = (
+  <React.Fragment>
+    {[1, 2, 3].map(item => {
+      return <div key={item}>{item}</div>;
+    })}
+    {[1, 2, 3].map(item => {
+      return <div key={item}>{item}</div>;
+    })}
+  </React.Fragment>
+);
+"
+`;
+
+exports[`each-multiple html output: generated html 1`] = `
+Array [
+  <div>
+    1
+  </div>,
+  <div>
+    2
+  </div>,
+  <div>
+    3
+  </div>,
+  <div>
+    1
+  </div>,
+  <div>
+    2
+  </div>,
+  <div>
+    3
+  </div>,
+]
+`;
+
+exports[`each-multiple static html output: static html 1`] = `"<div>1</div><div>2</div><div>3</div><div>1</div><div>2</div><div>3</div>"`;
+
 exports[`if JavaScript output: transformed source code 1`] = `
 "module.exports = false ? <p key=\\"pug:0:0\\">Truthy</p> : null;
 "

--- a/src/__tests__/__snapshots__/plain-js.test.js.snap
+++ b/src/__tests__/__snapshots__/plain-js.test.js.snap
@@ -46,20 +46,9 @@ exports[`code-multiline html output: generated html 1`] = `null`;
 exports[`code-multiline static html output: static html 1`] = `""`;
 
 exports[`each JavaScript output: transformed source code 1`] = `
-"module.exports = ((_pug_nodes, _pug_arr) => {
-  if (!(_pug_arr == null || Array.isArray(_pug_arr)))
-    throw new Error(
-      'Expected \\"[1, 2, 3]\\" to be an array because it is passed to each.'
-    );
-  if (_pug_arr == null || _pug_arr.length === 0) return undefined;
-
-  for (let _pug_index = 0; _pug_index < _pug_arr.length; _pug_index++) {
-    const item = _pug_arr[_pug_index];
-    _pug_nodes[_pug_nodes.length] = <div key={\\"pug\\" + item + \\":0\\"}>{item}</div>;
-  }
-
-  return _pug_nodes;
-})([], [1, 2, 3]);
+"module.exports = [1, 2, 3].map(item => {
+  return <div key={\\"pug\\" + item + \\":0\\"}>{item}</div>;
+});
 "
 `;
 

--- a/src/__tests__/__snapshots__/react-fragment.test.js.snap
+++ b/src/__tests__/__snapshots__/react-fragment.test.js.snap
@@ -22,22 +22,9 @@ exports[`basic static html output: static html 1`] = `"<div></div><div></div>"`;
 exports[`with each JavaScript output: transformed source code 1`] = `
 "module.exports = (
   <React.Fragment>
-    {((_pug_nodes, _pug_arr) => {
-      if (!(_pug_arr == null || Array.isArray(_pug_arr)))
-        throw new Error(
-          'Expected \\"[1, 2, 3]\\" to be an array because it is passed to each.'
-        );
-      if (_pug_arr == null || _pug_arr.length === 0) return undefined;
-
-      for (let _pug_index = 0; _pug_index < _pug_arr.length; _pug_index++) {
-        const item = _pug_arr[_pug_index];
-        _pug_nodes[_pug_nodes.length] = (
-          <div key={\\"pug\\" + item + \\":0\\"}>{item}</div>
-        );
-      }
-
-      return _pug_nodes;
-    })([], [1, 2, 3])}
+    {[1, 2, 3].map(item => {
+      return <div key={\\"pug\\" + item + \\":0\\"}>{item}</div>;
+    })}
     <div>Next item</div>
   </React.Fragment>
 );

--- a/src/__tests__/__snapshots__/react-fragment.test.js.snap
+++ b/src/__tests__/__snapshots__/react-fragment.test.js.snap
@@ -23,7 +23,7 @@ exports[`with each JavaScript output: transformed source code 1`] = `
 "module.exports = (
   <React.Fragment>
     {[1, 2, 3].map(item => {
-      return <div key={\\"pug\\" + item + \\":0\\"}>{item}</div>;
+      return <div key={item}>{item}</div>;
     })}
     <div>Next item</div>
   </React.Fragment>

--- a/src/__tests__/nested-loops.input.js
+++ b/src/__tests__/nested-loops.input.js
@@ -9,4 +9,22 @@ module.exports = pug`
         each c, i in [1,2,3]
           - const name = 'c';
           div(key=c)= name + c
+
+    each list, index in [[1, 2, 3], ['a', 'b', 'c']]
+      each item in list
+        div(key=item + index data-value=item)
+
+    each list in [[1, 2, 3], 'text']
+      if Array.isArray(list)
+        each item in list
+          p(key=item)= item
+
+    each i in [1, 2]
+      - const anotherArray = ['a', 'b', 'c']
+      each item, index in anotherArray
+        p(key=index)= item
+
+    each i in [1, 2]
+      div(key=i)= i
+      div(key=i + 10)= i
 `;

--- a/src/__tests__/plain-js-each-multiple.input.js
+++ b/src/__tests__/plain-js-each-multiple.input.js
@@ -1,0 +1,7 @@
+module.exports = pug`
+  each item in [1, 2, 3]
+    div(key=item)= item
+
+  each item in [1, 2, 3]
+    div(key=item)= item
+`;

--- a/src/__tests__/plain-js.test.js
+++ b/src/__tests__/plain-js.test.js
@@ -16,6 +16,10 @@ describe('each', () => {
   testHelper(__dirname + '/plain-js-each.input.js');
 });
 
+describe('each-multiple', () => {
+  testHelper(__dirname + '/plain-js-each-multiple.input.js');
+});
+
 describe('while', () => {
   testHelper(__dirname + '/plain-js-while.input.js');
 });

--- a/src/block-key.js
+++ b/src/block-key.js
@@ -110,31 +110,7 @@ export class DynamicBlock implements Key {
       this._update();
     });
   }
-  _update() {
-    // const parentKey = this._parentKey;
-    // const localKey = this._localKey;
-    // if (this._ended && this._parentEnded && localKey) {
-    //   if (!parentKey) {
-    //     throw new Error(
-    //       'There should always be a parent key once it has ended',
-    //     );
-    //   }
-    //   while (this._pending.length) {
-    //     this._pending.shift()(localKey);
-    //   }
-    // } else if (this._ended && this._parentEnded && this._pending.length) {
-    //   const err = error(
-    //     'MISSING_KEY',
-    //     'You must specify a key for the first item in any loops.',
-    //     {
-    //       line: this._lineNumberForError,
-    //       filename: 'pug',
-    //       src: this._srcForError,
-    //     },
-    //   );
-    //   throw err;
-    // }
-  }
+  _update() {}
 
   getKey(fn: OnKeyCallback) {
     if (this._pending.indexOf(fn) === -1) {
@@ -146,28 +122,7 @@ export class DynamicBlock implements Key {
     this._update();
   }
 
-  handleAttributes(attrs: Array<JSXAttribute | JSXSpreadAttribute>) {
-    // for (const _attr of attrs) {
-    //   const attr = t.asJSXAttribute(_attr);
-    //   if (attr && t.isJSXIdentifier(attr.name, {name: 'key'})) {
-    //     if (this._localKey) {
-    //       return;
-    //     }
-    //     const value = t.asJSXExpressionContainer(attr.value);
-    //     if (value && value.expression) {
-    //       this._localKey = value.expression;
-    //       this._update();
-    //       // remove the attribute and replace with the properly nested version
-    //       attrs.splice(attrs.indexOf(attr), 1);
-    //     } else {
-    //       return;
-    //     }
-    //   }
-    // }
-    // this.getKey(key => {
-    //   attrs.push(t.jSXAttribute(t.jSXIdentifier('key'), toJsxValue(key)));
-    // });
-  }
+  handleAttributes() {}
 
   end() {
     this._ended = true;

--- a/src/block-key.js
+++ b/src/block-key.js
@@ -111,29 +111,29 @@ export class DynamicBlock implements Key {
     });
   }
   _update() {
-    const parentKey = this._parentKey;
-    const localKey = this._localKey;
-    if (this._ended && this._parentEnded && localKey) {
-      if (!parentKey) {
-        throw new Error(
-          'There should always be a parent key once it has ended',
-        );
-      }
-      while (this._pending.length) {
-        this._pending.shift()(localKey);
-      }
-    } else if (this._ended && this._parentEnded && this._pending.length) {
-      const err = error(
-        'MISSING_KEY',
-        'You must specify a key for the first item in any loops.',
-        {
-          line: this._lineNumberForError,
-          filename: 'pug',
-          src: this._srcForError,
-        },
-      );
-      throw err;
-    }
+    // const parentKey = this._parentKey;
+    // const localKey = this._localKey;
+    // if (this._ended && this._parentEnded && localKey) {
+    //   if (!parentKey) {
+    //     throw new Error(
+    //       'There should always be a parent key once it has ended',
+    //     );
+    //   }
+    //   while (this._pending.length) {
+    //     this._pending.shift()(localKey);
+    //   }
+    // } else if (this._ended && this._parentEnded && this._pending.length) {
+    //   const err = error(
+    //     'MISSING_KEY',
+    //     'You must specify a key for the first item in any loops.',
+    //     {
+    //       line: this._lineNumberForError,
+    //       filename: 'pug',
+    //       src: this._srcForError,
+    //     },
+    //   );
+    //   throw err;
+    // }
   }
 
   getKey(fn: OnKeyCallback) {

--- a/src/block-key.js
+++ b/src/block-key.js
@@ -88,7 +88,7 @@ export class StaticBlock implements Key {
 
 /*
  * Dynamic blocks are used for real iteration, we require the user to add a key to
- * at least one elemnt within the array, and then we build keys for all the other
+ * at least one element within the array, and then we build keys for all the other
  * elements from that one intial key.
  */
 export class DynamicBlock implements Key {
@@ -119,9 +119,8 @@ export class DynamicBlock implements Key {
           'There should always be a parent key once it has ended',
         );
       }
-      const key = t.binaryExpression('+', parentKey, localKey);
       while (this._pending.length) {
-        this._pending.shift()(key);
+        this._pending.shift()(localKey);
       }
     } else if (this._ended && this._parentEnded && this._pending.length) {
       const err = error(
@@ -141,33 +140,33 @@ export class DynamicBlock implements Key {
     if (this._pending.indexOf(fn) === -1) {
       const index = this._index++;
       this._pending.push((key: Expression) => {
-        return fn(addString(key, t.stringLiteral(':' + index)));
+        return fn(key);
       });
     }
     this._update();
   }
 
   handleAttributes(attrs: Array<JSXAttribute | JSXSpreadAttribute>) {
-    for (const _attr of attrs) {
-      const attr = t.asJSXAttribute(_attr);
-      if (attr && t.isJSXIdentifier(attr.name, {name: 'key'})) {
-        if (this._localKey) {
-          return;
-        }
-        const value = t.asJSXExpressionContainer(attr.value);
-        if (value && value.expression) {
-          this._localKey = value.expression;
-          this._update();
-          // remove the attribute and replace with the properly nested version
-          attrs.splice(attrs.indexOf(attr), 1);
-        } else {
-          return;
-        }
-      }
-    }
-    this.getKey(key => {
-      attrs.push(t.jSXAttribute(t.jSXIdentifier('key'), toJsxValue(key)));
-    });
+    // for (const _attr of attrs) {
+    //   const attr = t.asJSXAttribute(_attr);
+    //   if (attr && t.isJSXIdentifier(attr.name, {name: 'key'})) {
+    //     if (this._localKey) {
+    //       return;
+    //     }
+    //     const value = t.asJSXExpressionContainer(attr.value);
+    //     if (value && value.expression) {
+    //       this._localKey = value.expression;
+    //       this._update();
+    //       // remove the attribute and replace with the properly nested version
+    //       attrs.splice(attrs.indexOf(attr), 1);
+    //     } else {
+    //       return;
+    //     }
+    //   }
+    // }
+    // this.getKey(key => {
+    //   attrs.push(t.jSXAttribute(t.jSXIdentifier('key'), toJsxValue(key)));
+    // });
   }
 
   end() {

--- a/src/visitors/Each.js
+++ b/src/visitors/Each.js
@@ -13,7 +13,7 @@ function getAlternate(node: Object, context: Context): Expression {
         childContext,
       );
       if (children.length === 0) {
-        return t.identifier('undefined');
+        return t.identifier('null');
       }
       if (children.length === 1) {
         return children[0];

--- a/src/visitors/Each.js
+++ b/src/visitors/Each.js
@@ -23,12 +23,11 @@ function getAlternate(node: Object, context: Context): Expression {
   );
 }
 
-const getBody = (node: Object, context: Context): Expression => {
+const getBody = (node: Object, context: Context): BlockStatement => {
   const bodyContent = [];
 
-  const {result, variables} = context.dynamicBlock(
-    (childContext: Context): Expression =>
-      visitExpressions(node.block.nodes, childContext),
+  const {result, variables} = context.dynamicBlock((childContext: Context) =>
+    visitExpressions(node.block.nodes, childContext),
   );
 
   if (variables.length) {

--- a/src/visitors/Each.js
+++ b/src/visitors/Each.js
@@ -5,56 +5,6 @@ import type Context from '../context';
 import t from '../lib/babel-types';
 import {visitExpressions} from '../visitors';
 
-function getLoop(
-  node: Object,
-  context: Context,
-  id: Identifier,
-  arrayToIterateOver: Identifier,
-  arrayLength: MemberExpression,
-): Statement {
-  const index = node.key
-    ? t.identifier(node.key)
-    : context.generateUidIdentifier('pug_index');
-  const init = t.variableDeclaration('let', [
-    t.variableDeclarator(index, t.numericLiteral(0)),
-  ]);
-  const test = t.binaryExpression('<', index, arrayLength);
-  const update = t.updateExpression('++', index);
-  const {result: body, variables} = context.dynamicBlock(childContext =>
-    [
-      t.variableDeclaration('const', [
-        t.variableDeclarator(
-          t.identifier(node.val),
-          t.memberExpression(arrayToIterateOver, index, true),
-        ),
-      ]),
-    ].concat(
-      visitExpressions(node.block.nodes, childContext).map(exp =>
-        t.expressionStatement(
-          t.assignmentExpression(
-            '=',
-            t.memberExpression(
-              id,
-              t.memberExpression(id, t.identifier('length')),
-              true,
-            ),
-            exp,
-          ),
-        ),
-      ),
-    ),
-  );
-  if (variables.length) {
-    body.unshift(
-      t.variableDeclaration(
-        'let',
-        variables.map(id => t.variableDeclarator(id)),
-      ),
-    );
-  }
-  return t.forStatement(init, test, update, t.blockStatement(body));
-}
-
 function getAlternate(node: Object, context: Context): Expression {
   return context.staticBlock(
     (childContext: Context): Expression => {
@@ -72,67 +22,64 @@ function getAlternate(node: Object, context: Context): Expression {
     },
   );
 }
-function getTypeErrorTest(
-  node: Object,
-  context: Context,
-  arrayToIterateOver: Identifier,
-): Statement {
-  return t.ifStatement(
-    t.unaryExpression(
-      '!',
-      t.logicalExpression(
-        '||',
-        t.binaryExpression('==', arrayToIterateOver, t.nullLiteral()),
-        t.callExpression(
-          t.memberExpression(t.identifier('Array'), t.identifier('isArray')),
-          [arrayToIterateOver],
-        ),
-      ),
-    ),
-    t.throwStatement(
-      t.newExpression(t.identifier('Error'), [
-        t.stringLiteral(
-          'Expected "' +
-            node.obj +
-            '" to be an array because it is passed to each.',
-        ),
-      ]),
-    ),
+
+const getBody = (node: Object, context: Context): Expression => {
+  const bodyContent = [];
+
+  const {result, variables} = context.dynamicBlock(
+    (childContext: Context): Expression =>
+      visitExpressions(node.block.nodes, childContext),
   );
-}
+
+  if (variables.length) {
+    bodyContent.unshift(
+      t.variableDeclaration(
+        'let',
+        variables.map(id => t.variableDeclarator(id)),
+      ),
+    );
+  }
+
+  if (result.length > 1) {
+    bodyContent.push(t.returnStatement(t.arrayExpression(result)));
+  } else {
+    bodyContent.push(t.returnStatement(result[0]));
+  }
+
+  return t.blockStatement(bodyContent);
+};
 
 const WhileVisitor = {
   expression(node: Object, context: Context): Expression {
-    const id = context.generateUidIdentifier('pug_nodes');
+    const bodyArgs = [t.identifier(node.val)];
 
-    const arrayToIterateOver = context.generateUidIdentifier('pug_arr');
-    const arrayLength = t.memberExpression(
-      arrayToIterateOver,
-      t.identifier('length'),
+    if (node.key) {
+      bodyArgs.push(t.identifier(node.key));
+    }
+
+    const list = parseExpression(node.obj, context);
+
+    const callExpression = t.callExpression(
+      t.memberExpression(list, t.identifier('map')),
+      [t.arrowFunctionExpression(bodyArgs, getBody(node, context))],
     );
 
-    const typeErrorTest = getTypeErrorTest(node, context, arrayToIterateOver);
-    const loop = getLoop(node, context, id, arrayToIterateOver, arrayLength);
-    const alternate = getAlternate(node, context);
-
-    const body = t.blockStatement([
-      typeErrorTest,
-      t.ifStatement(
+    if (node.alternate) {
+      return t.conditionalExpression(
         t.logicalExpression(
-          '||',
-          t.binaryExpression('==', arrayToIterateOver, t.nullLiteral()),
-          t.binaryExpression('===', arrayLength, t.numericLiteral(0)),
+          '&&',
+          t.callExpression(
+            t.memberExpression(t.identifier('Array'), t.identifier('isArray')),
+            [list],
+          ),
+          t.memberExpression(list, t.identifier('length')),
         ),
-        t.returnStatement(alternate),
-      ),
-      loop,
-      t.returnStatement(id),
-    ]);
+        callExpression,
+        getAlternate(node, context),
+      );
+    }
 
-    return t.callExpression(
-      t.arrowFunctionExpression([id, arrayToIterateOver], body),
-      [t.arrayExpression([]), parseExpression(node.obj, context)],
-    );
+    return callExpression;
   },
 };
 


### PR DESCRIPTION
So instead of transpiling `each` into own loops with own logic and conditions, we transpile it into `.map`.

For example:

```pug
each item in [1, 2, 3]
  p(key=item)= item
```

```jsx
[1, 2, 3].map(item => (
  <p key={item}>{item}</p>
))
```