### PR TITLE
fix parser error on '…\n…' template expression

### DIFF
--- a/src/__tests__/__snapshots__/multi-line-escaped-text.test.js.snap
+++ b/src/__tests__/__snapshots__/multi-line-escaped-text.test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`JavaScript output: transformed source code 1`] = `"module.exports = <div>foo{\\"\\\\n\\"}bar</div>;"`;
+
+exports[`html output: generated html 1`] = `
+<div>
+  foo
+  
+
+  bar
+</div>
+`;
+
+exports[`static html output: static html 1`] = `
+"<div>foo
+bar</div>"
+`;

--- a/src/__tests__/multi-line-escaped-text.input.js
+++ b/src/__tests__/multi-line-escaped-text.input.js
@@ -1,0 +1,1 @@
+module.exports = pug`div.\n    foo\n    bar`;

--- a/src/__tests__/multi-line-escaped-text.test.js
+++ b/src/__tests__/multi-line-escaped-text.test.js
@@ -1,0 +1,3 @@
+import testHelper from './test-helper';
+
+testHelper(__dirname + '/multi-line-escaped-text.input.js');

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ export default function(babel) {
             template = quasis[0].value.raw;
           }
 
-          let src = template.split('\n');
+          let src = template.replace(/\\n/g, '\n').split('\n');
 
           const minIndent = common(
             src


### PR DESCRIPTION
Change to accept template strings like:

```javascript
pug`\n  div\n    p test\n`
```

Which is identical to

```javascript
pug`
  div
    p test
`
```