### PR TITLE
Add new option: `attributeAlias`

### DIFF
--- a/src/__tests__/__snapshots__/attributes-transformation.test.js.snap
+++ b/src/__tests__/__snapshots__/attributes-transformation.test.js.snap
@@ -10,10 +10,10 @@ module.exports = (
   <div>
     <div className=\\"one two\\" />
     <div className=\\"one two\\" />
-    <div className={100} />
+    <div className=\\"100\\" />
     <div className={array} />
     <div className={object} />
-    <div className={[\\"one\\", \\"two\\"]} />
+    <div className=\\"one two\\" />
     <div className={[\\"one\\", \\"two\\"].join(\\" \\")} />
     <div
       className={{
@@ -24,18 +24,15 @@ module.exports = (
     <div before=\\"before\\" {...object} />
     <div before=\\"before\\" {...object} after=\\"after\\" />
     <div className=\\"mix one two\\" />
-    <div className={\\"mix \\" + 100} />
-    <div className={\\"mix \\" + array} />
-    <div className={\\"mix \\" + object} />
-    <div className={[\\"mix\\", \\"one\\", \\"two\\"]} />
-    <div className={\\"mix \\" + [\\"one\\", \\"two\\"].join(\\" \\")} />
+    <div className=\\"mix 100\\" />
+    <div className={\`mix \${array}\`} />
+    <div className={\`mix \${object}\`} />
+    <div className=\\"mix one two\\" />
+    <div className={\`mix \${[\\"one\\", \\"two\\"].join(\\" \\")}\`} />
     <div
-      className={
-        \\"mix \\" +
-        {
-          first: true
-        }
-      }
+      className={\`mix \${{
+        first: true
+      }}\`}
     />
     <div {...object} after=\\"after\\" className=\\"mix\\" />
     <div before=\\"before\\" {...object} className=\\"mix\\" />
@@ -54,7 +51,7 @@ exports[`html output: generated html 1`] = `
     className="one two"
   />
   <div
-    className={100}
+    className="100"
   />
   <div
     className={
@@ -73,12 +70,7 @@ exports[`html output: generated html 1`] = `
     }
   />
   <div
-    className={
-      Array [
-        "one",
-        "two",
-      ]
-    }
+    className="one two"
   />
   <div
     className="one two"
@@ -119,13 +111,7 @@ exports[`html output: generated html 1`] = `
     className="mix [object Object]"
   />
   <div
-    className={
-      Array [
-        "mix",
-        "one",
-        "two",
-      ]
-    }
+    className="mix one two"
   />
   <div
     className="mix one two"
@@ -155,4 +141,4 @@ exports[`html output: generated html 1`] = `
 </div>
 `;
 
-exports[`static html output: static html 1`] = `"<div><div class=\\"one two\\"></div><div class=\\"one two\\"></div><div class=\\"100\\"></div><div class=\\"arr-one,arr-two\\"></div><div class=\\"[object Object]\\"></div><div class=\\"one,two\\"></div><div class=\\"one two\\"></div><div class=\\"[object Object]\\"></div><div first=\\"one-in-object\\" second=\\"two-in-object\\" after=\\"after\\"></div><div before=\\"before\\" first=\\"one-in-object\\" second=\\"two-in-object\\"></div><div before=\\"before\\" first=\\"one-in-object\\" second=\\"two-in-object\\" after=\\"after\\"></div><div class=\\"mix one two\\"></div><div class=\\"mix 100\\"></div><div class=\\"mix arr-one,arr-two\\"></div><div class=\\"mix [object Object]\\"></div><div class=\\"mix,one,two\\"></div><div class=\\"mix one two\\"></div><div class=\\"mix [object Object]\\"></div><div first=\\"one-in-object\\" second=\\"two-in-object\\" after=\\"after\\" class=\\"mix\\"></div><div before=\\"before\\" first=\\"one-in-object\\" second=\\"two-in-object\\" class=\\"mix\\"></div><div before=\\"before\\" first=\\"one-in-object\\" second=\\"two-in-object\\" after=\\"after\\" class=\\"mix\\"></div></div>"`;
+exports[`static html output: static html 1`] = `"<div><div class=\\"one two\\"></div><div class=\\"one two\\"></div><div class=\\"100\\"></div><div class=\\"arr-one,arr-two\\"></div><div class=\\"[object Object]\\"></div><div class=\\"one two\\"></div><div class=\\"one two\\"></div><div class=\\"[object Object]\\"></div><div first=\\"one-in-object\\" second=\\"two-in-object\\" after=\\"after\\"></div><div before=\\"before\\" first=\\"one-in-object\\" second=\\"two-in-object\\"></div><div before=\\"before\\" first=\\"one-in-object\\" second=\\"two-in-object\\" after=\\"after\\"></div><div class=\\"mix one two\\"></div><div class=\\"mix 100\\"></div><div class=\\"mix arr-one,arr-two\\"></div><div class=\\"mix [object Object]\\"></div><div class=\\"mix one two\\"></div><div class=\\"mix one two\\"></div><div class=\\"mix [object Object]\\"></div><div first=\\"one-in-object\\" second=\\"two-in-object\\" after=\\"after\\" class=\\"mix\\"></div><div before=\\"before\\" first=\\"one-in-object\\" second=\\"two-in-object\\" class=\\"mix\\"></div><div before=\\"before\\" first=\\"one-in-object\\" second=\\"two-in-object\\" after=\\"after\\" class=\\"mix\\"></div></div>"`;

--- a/src/__tests__/__snapshots__/option-attribute-alias.test.js.snap
+++ b/src/__tests__/__snapshots__/option-attribute-alias.test.js.snap
@@ -1,9 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Expect an error to be thrown 1`] = `
+"<basedir>/src/__tests__/option-attribute-alias.input.js:13
+    11|     p.b1.b2(class=\\"b3 b4\\")
+    12|     p.c1(className=\\"c2 c3\\")
+  > 13|     p.d1(class=classes)
+    14|     p.e1(class=['e2', 'e3'])
+    15|     p.f1(class=['f2', ...classesArray])
+    16|     p(class=$.Red)
+
+We can't use expressions in shorthands, use \\"className\\" instead of \\"class\\""
+`;
+
 exports[`JavaScript output: transformed source code 1`] = `
-"const classes = [\\"e2\\", \\"e3\\"];
-const showG = true;
-const showH = false;
+"const $ = {
+  Red: \\"color-red\\"
+};
+const classes = \\"d2 d3\\";
+const classesArray = [\\"f3\\", $.Red];
+const showK = true;
+const showL = false;
 
 const handleClick = () => {};
 
@@ -12,23 +28,27 @@ module.exports = (
   <div className=\\"a1\\">
     <p className=\\"b1 b2 b3 b4\\" />
     <p className=\\"c1 c2 c3\\" />
-    <p className={\\"d1\\"} />
-    <p className={\\"e1\\"} />
-    <p className=\\"f1 f2 f3 f4 f5\\" />
-    <p className={\\"g1\\"} />
-    <p className={\\"h1\\"} />
-    <a onClick={handleClick} className=\\"i1\\" />
+    <p className={\`d1 \${classes}\`} />
+    <p className=\\"e1 e2 e3\\" />
+    <p className=\\"f1 f2\\" />
+    <p className={$.Red} />
+    <p className={\`g1 \${$.Red}\`} />
+    <p className={\`i1 \${\`i2 \${$.Red}\`}\`} />
+    <p className=\\"j1 j2 j3 j4 j5\\" />
+    <p className={showK && \\"k1\\"} />
+    <p className={\`l1 \${showL ? \\"l2\\" : \\"\\"}\`} />
+    <a onClick={handleClick} className=\\"m1\\" />
     <svg
       dangerouslySetInnerHTML={{
         __html: \\"<g></g>\\"
       }}
-      className=\\"j1\\"
+      className=\\"n1\\"
     />
     <svg
       dangerouslySetInnerHTML={{
         __html: svgGroup
       }}
-      className=\\"k1\\"
+      className=\\"o1\\"
     />
   </div>
 );
@@ -46,26 +66,38 @@ exports[`html output: generated html 1`] = `
     className="c1 c2 c3"
   />
   <p
-    className="d1"
+    className="d1 d2 d3"
   />
   <p
-    className="e1"
+    className="e1 e2 e3"
   />
   <p
-    className="f1 f2 f3 f4 f5"
+    className="f1 f2"
   />
   <p
-    className="g1"
+    className="color-red"
   />
   <p
-    className="h1"
+    className="g1 color-red"
+  />
+  <p
+    className="i1 i2 color-red"
+  />
+  <p
+    className="j1 j2 j3 j4 j5"
+  />
+  <p
+    className="k1"
+  />
+  <p
+    className="l1 "
   />
   <a
-    className="i1"
+    className="m1"
     onClick={[Function]}
   />
   <svg
-    className="j1"
+    className="n1"
     dangerouslySetInnerHTML={
       Object {
         "__html": "<g></g>",
@@ -73,7 +105,7 @@ exports[`html output: generated html 1`] = `
     }
   />
   <svg
-    className="k1"
+    className="o1"
     dangerouslySetInnerHTML={
       Object {
         "__html": "<g></g>",
@@ -83,4 +115,4 @@ exports[`html output: generated html 1`] = `
 </div>
 `;
 
-exports[`static html output: static html 1`] = `"<div class=\\"a1\\"><p class=\\"b1 b2 b3 b4\\"></p><p class=\\"c1 c2 c3\\"></p><p class=\\"d1\\"></p><p class=\\"e1\\"></p><p class=\\"f1 f2 f3 f4 f5\\"></p><p class=\\"g1\\"></p><p class=\\"h1\\"></p><a class=\\"i1\\"></a><svg class=\\"j1\\"><g></g></svg><svg class=\\"k1\\"><g></g></svg></div>"`;
+exports[`static html output: static html 1`] = `"<div class=\\"a1\\"><p class=\\"b1 b2 b3 b4\\"></p><p class=\\"c1 c2 c3\\"></p><p class=\\"d1 d2 d3\\"></p><p class=\\"e1 e2 e3\\"></p><p class=\\"f1 f2\\"></p><p class=\\"color-red\\"></p><p class=\\"g1 color-red\\"></p><p class=\\"i1 i2 color-red\\"></p><p class=\\"j1 j2 j3 j4 j5\\"></p><p class=\\"k1\\"></p><p class=\\"l1 \\"></p><a class=\\"m1\\"></a><svg class=\\"n1\\"><g></g></svg><svg class=\\"o1\\"><g></g></svg></div>"`;

--- a/src/__tests__/__snapshots__/option-attribute-alias.test.js.snap
+++ b/src/__tests__/__snapshots__/option-attribute-alias.test.js.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`JavaScript output: transformed source code 1`] = `
+"const classes = [\\"e2\\", \\"e3\\"];
+const showG = true;
+const showH = false;
+
+const handleClick = () => {};
+
+const svgGroup = \\"<g></g>\\";
+module.exports = (
+  <div className=\\"a1\\">
+    <p className=\\"b1 b2 b3 b4\\" />
+    <p className=\\"c1 c2 c3\\" />
+    <p className={\\"d1\\"} />
+    <p className={\\"e1\\"} />
+    <p className=\\"f1 f2 f3 f4 f5\\" />
+    <p className={\\"g1\\"} />
+    <p className={\\"h1\\"} />
+    <a onClick={handleClick} className=\\"i1\\" />
+    <svg
+      dangerouslySetInnerHTML={{
+        __html: \\"<g></g>\\"
+      }}
+      className=\\"j1\\"
+    />
+    <svg
+      dangerouslySetInnerHTML={{
+        __html: svgGroup
+      }}
+      className=\\"k1\\"
+    />
+  </div>
+);
+"
+`;
+
+exports[`html output: generated html 1`] = `
+<div
+  className="a1"
+>
+  <p
+    className="b1 b2 b3 b4"
+  />
+  <p
+    className="c1 c2 c3"
+  />
+  <p
+    className="d1"
+  />
+  <p
+    className="e1"
+  />
+  <p
+    className="f1 f2 f3 f4 f5"
+  />
+  <p
+    className="g1"
+  />
+  <p
+    className="h1"
+  />
+  <a
+    className="i1"
+    onClick={[Function]}
+  />
+  <svg
+    className="j1"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<g></g>",
+      }
+    }
+  />
+  <svg
+    className="k1"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<g></g>",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`static html output: static html 1`] = `"<div class=\\"a1\\"><p class=\\"b1 b2 b3 b4\\"></p><p class=\\"c1 c2 c3\\"></p><p class=\\"d1\\"></p><p class=\\"e1\\"></p><p class=\\"f1 f2 f3 f4 f5\\"></p><p class=\\"g1\\"></p><p class=\\"h1\\"></p><a class=\\"i1\\"></a><svg class=\\"j1\\"><g></g></svg><svg class=\\"k1\\"><g></g></svg></div>"`;

--- a/src/__tests__/__snapshots__/option-class-attribute.test.js.snap
+++ b/src/__tests__/__snapshots__/option-class-attribute.test.js.snap
@@ -16,7 +16,7 @@ module.exports = (
       return (
         <p
           key={item}
-          className={\\"seventh-a seventh-b \\" + (\\"seventh-i-\\" + item)}
+          className={\`seventh-a seventh-b \${\\"seventh-i-\\" + item}\`}
         />
       );
     })}

--- a/src/__tests__/option-attribute-alias.input.js
+++ b/src/__tests__/option-attribute-alias.input.js
@@ -1,0 +1,22 @@
+const classes = ['e2', 'e3'];
+const showG = true
+const showH = false
+const handleClick = () => {};
+const svgGroup = '<g></g>';
+
+module.exports = pug`
+  div.a1
+    p.b1.b2(class="b3 b4")
+    p.c1(className="c2 c3")
+    p.d1(class=['d2', 'd3'])
+    p.e1(class=classes)
+    p.f1(
+      class="f2 f3",
+      className="f4 f5"
+    )
+    p.g1(class=(showG && "g2"))
+    p.h1(class=(showH && "h2"))
+    a.i1(@click=handleClick)
+    svg.j1(@html={ __html: "<g></g>" })
+    svg.k1(@html={ __html: svgGroup })
+`;

--- a/src/__tests__/option-attribute-alias.input.js
+++ b/src/__tests__/option-attribute-alias.input.js
@@ -1,6 +1,8 @@
-const classes = ['e2', 'e3'];
-const showG = true
-const showH = false
+const $ = {Red: 'color-red'};
+const classes = 'd2 d3';
+const classesArray = ['f3', $.Red];
+const showK = true;
+const showL = false;
 const handleClick = () => {};
 const svgGroup = '<g></g>';
 
@@ -8,15 +10,18 @@ module.exports = pug`
   div.a1
     p.b1.b2(class="b3 b4")
     p.c1(className="c2 c3")
-    p.d1(class=['d2', 'd3'])
-    p.e1(class=classes)
-    p.f1(
-      class="f2 f3",
-      className="f4 f5"
-    )
-    p.g1(class=(showG && "g2"))
-    p.h1(class=(showH && "h2"))
-    a.i1(@click=handleClick)
-    svg.j1(@html={ __html: "<g></g>" })
-    svg.k1(@html={ __html: svgGroup })
+    p.d1(class=classes)
+    p.e1(class=['e2', 'e3'])
+    p.f1(class=['f2', ...classesArray])
+    p(class=$.Red)
+    p(class=${`g1 ${$.Red}`})
+    p.i1(class=${`i2 ${$.Red}`})
+    p.j1(
+      class="j2 j3",
+      className="j4 j5")
+    p(class=(showK && "k1"))
+    p.l1(class=(showL ? "l2" : ""))
+    a.m1(@click=handleClick)
+    svg.n1(@html={ __html: "<g></g>" })
+    svg.o1(@html={ __html: svgGroup })
 `;

--- a/src/__tests__/option-attribute-alias.test.js
+++ b/src/__tests__/option-attribute-alias.test.js
@@ -1,0 +1,11 @@
+import testHelper, {mockConsoleErrors} from './test-helper';
+
+mockConsoleErrors();
+
+testHelper(__dirname + '/option-attribute-alias.input.js', {
+  attributeAlias: {
+    class: 'className',
+    '@click': 'onClick',
+    '@html': 'dangerouslySetInnerHTML',
+  },
+});

--- a/src/__tests__/option-attribute-alias.test.js
+++ b/src/__tests__/option-attribute-alias.test.js
@@ -1,6 +1,6 @@
-import testHelper, {mockConsoleErrors} from './test-helper';
+import testHelper, {testCompileError} from './test-helper';
 
-mockConsoleErrors();
+testCompileError(__dirname + '/option-attribute-alias.input.js');
 
 testHelper(__dirname + '/option-attribute-alias.input.js', {
   attributeAlias: {

--- a/src/context.js
+++ b/src/context.js
@@ -15,6 +15,9 @@ type Variable = {
 
 type Options = {
   classAttribute: string,
+  attributeAlias: {
+    [string]: string,
+  },
 };
 
 class Context {

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import {setBabelTypes} from './lib/babel-types';
 
 const DEFAULT_OPTIONS = {
   classAttribute: 'className',
+  attributeAlias: {},
 };
 
 export default function(babel) {

--- a/src/visitors/Tag.js
+++ b/src/visitors/Tag.js
@@ -81,8 +81,10 @@ function getAttributes(node: Object, context: Context): Array<Attribute> {
             );
           }
 
-          classesViaShorthand.push(expr);
-          return null;
+          if (!context._options.attributeAlias[name]) {
+            classesViaShorthand.push(expr);
+            return null;
+          }
         }
 
         if (attrName === context._options.classAttribute) {
@@ -127,6 +129,7 @@ function getAttributesAndChildren(
 } {
   const children = getChildren(node, context);
 
+  // TODO Implement node.attributeBlocks
   if (node.attributeBlocks.length) {
     throw new Error('Attribute blocks are not yet supported in react-pug');
   }

--- a/src/visitors/Tag.js
+++ b/src/visitors/Tag.js
@@ -45,21 +45,15 @@ function getAttributes(node: Object, context: Context): Array<Attribute> {
   const attrs: Array<Attribute> = node.attrs
     .map(
       ({name, val, mustEscape}: PugAttribute): Attribute | null => {
-        if (/\.\.\./.test(name) && val === true) {
+        if (/^\.\.\./.test(name)) {
+          if (!val) {
+            throw new Error('spread attributes must not have a value');
+          }
           return t.jSXSpreadAttribute(parseExpression(name.substr(3), context));
         }
 
-        // TODO: Need to drop all aliases for attributes
-        switch (name) {
-          case 'for':
-            name = 'htmlFor';
-            break;
-          case 'maxlength':
-            name = 'maxLength';
-            break;
-        }
-
         const expr = parseExpression(String(val), context);
+        const attrName = context._options.attributeAlias[name] || name;
 
         if (!mustEscape) {
           const canSkipEscaping =
@@ -77,7 +71,7 @@ function getAttributes(node: Object, context: Context): Array<Attribute> {
           return null;
         }
 
-        if (name === 'class') {
+        if (attrName === 'class') {
           if (!t.isStringLiteral(expr)) {
             throw context.error(
               'INVALID_EXPRESSION',
@@ -91,7 +85,7 @@ function getAttributes(node: Object, context: Context): Array<Attribute> {
           return null;
         }
 
-        if (name === context._options.classAttribute) {
+        if (attrName === context._options.classAttribute) {
           classesViaAttribute.push(expr);
           return null;
         }
@@ -101,11 +95,7 @@ function getAttributes(node: Object, context: Context): Array<Attribute> {
           t.asJSXElement(expr) ||
           t.jSXExpressionContainer(expr);
 
-        if (/\.\.\./.test(name)) {
-          throw new Error('spread attributes must not have a value');
-        }
-
-        return t.jSXAttribute(t.jSXIdentifier(name), jsxValue);
+        return t.jSXAttribute(t.jSXIdentifier(attrName), jsxValue);
       },
     )
     .filter(Boolean);


### PR DESCRIPTION
I made a new option to solve https://github.com/pugjs/babel-plugin-transform-react-pug/issues/111, this option grant everyone can decide which syntax to use between:

```js
pug`div( class="box" )`
```

and

```js
pug`div( className="box" )`
```

But before that, I must implement expressional className so I can make `attributeAlias` works correctly.

This pull request brings two features in actual:

- New plugin option `attributeAlias`
- Implement expressional `className`

## Usage

##### `babel.config.js`
```js
{
  plugins: [
    // or shorthand:
    // ["transform-react-pug", {
    ["babel-plugin-transform-react-pug", {
      attributeAlias: {
        class: 'className'
      }
    }]
  ]
}
```

With `attributeAlias: { class: 'className' }` set, you can now write expressions inside `class` again just like the native syntax of Pug:

## Changes

### 1. Allow expression and array

_\*Pug allows pass [array as class attribute](https://pugjs.org/language/attributes.html#class-attributes) natively._

```js
const darkMode = true

const A = pug`
  div.box( class=("is-large " + (darkMode ? "is-dark" : "")) )
`

const B = pug`
  div.box( class=${`is-large ${darkMode && "is-dark" : ""`} )
`

const C = pug`
  div.box( class=["is-large", darkMode && "is-dark"] )
`
```

All renders to: (ignore there's extra spaces in A and B)

```js
<div className="box is-large is-dark" />
```

### 2. Correct syntax of `className`

_\*Also see: https://github.com/facebook/react/issues/3138_

Before:

```js
pug`
  div( class=100 )
  div( class=["A", "B"] )
`
// => <div className={100} />
// => <div className={["A", "B"]} />
```

After:

```js
pug`
  div( className=100 )`
  div( class=["A", "B"] )
`
// => <div className="100" />
// => <div className="A B" />
```

### 3. ClassName interpolation

```js
import $ from './style.css'

const A = pug`div( class=$.Box )`
// => <div className={$.Box} />

const B = pug`div( class=[$.Box, $.isLarge ] )`
// => <div className={`${$.Box} ${$.isLarge}`} />

const C = pug`div( class=["class-1", "class-2"] )`
// => <div className="class-1 class-2" />

const D = pug`div( class=["class-1", $.InterpolateClass, "class-2"] )`
// => <div className={`class-1 ${$.InterpolateClass} class-2`} />
```

### 4. Default alias (❗Breaking Change)

Now we don't parse there attributes in initiative:

- `for` => `htmlFor`
- `maxlength` => `maxLength`

To make it works like before, create aliases in your babelrc:

##### `babel.config.js`
```js
{
  plugins: [
    ["babel-plugin-transform-react-pug", {
      attributeAlias: {
        for: 'htmlFor',
        maxlength: 'maxLength'
      }
    }]
  ]
}
```

> Question:
>
> Is it a good idea that make `class` and `for` alias in default?

### 5. Limitation

Currently array spread operators are ignored, here's some sample:

```js
const classes = ["class-1", "class-2"]

pug`
  div.box( classes=["class-1", "class-2"] )
`
// => <div className="box class-1 class-2" />

pug`
  div.box( classes=classes )
`
// => <div className={`box ${classes}`} />

pug`
  div( class=["box", ...classes] )
`
// => <div className="box" /> // ...ignored
```

## More about `attributeAlias`

With this option, you can even do more than just classNames.

For example, you can create shorthands like that:

##### `babel.config.js`
```js
{
  plugins: [
    ["babel-plugin-transform-react-pug", {
      attributeAlias: {
        "@click": 'onClick',
        "@change": 'onChange',
        "@value": 'defaultValue',
        "@html": 'dangerouslySetInnerHTML'
      }
    }]
  ]
}
```

And feel the power:

```js
pug`
  button( @click=handleClick )
    | Button
`
// => <button onClick={handleClick}>Button</button>

pug`
  input( @change=setEmail, @value=email )
`
// => <input onChange={setEmail} defaultValue={email} />

pug`
  svg( @html={ __html: svgContentText } )
`
// => <svg dangerouslySetInnerHTML={{ __html: svgContentText }} />
```